### PR TITLE
Specify bioc-common-python version.

### DIFF
--- a/PIP-DEPENDENCIES--spb_history.txt
+++ b/PIP-DEPENDENCIES--spb_history.txt
@@ -1,4 +1,4 @@
-git+https://git@github.com/bioconductor/bioc-common-python.git
+git+https://git@github.com/bioconductor/bioc-common-python.git@0.6#bioconductor==bioconductor
 Django==1.8.4
 mechanize==0.2.5
 MySQL-python==1.2.5


### PR DESCRIPTION
Specifying our version of bioc-common-python, as per : 
- http://codeinthehole.com/writing/using-pip-and-requirementstxt-to-install-from-the-head-of-a-github-branch/
- https://coderwall.com/p/-wbo5q/pip-install-a-specific-github-repo-tag-or-branch

FYI @jimhester 
